### PR TITLE
Update action to node 20

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -11,13 +11,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        node-version: [ 12.x, 14.x, 16.x ]
+        node-version: [ 20.x, 21.x ]
     if: "startsWith( github.event.head_commit.message, 'version' ) && startsWith( github.ref, 'refs/tags/v' )"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -28,7 +28,7 @@ jobs:
     if: "startsWith( github.event.head_commit.message, 'version' ) && startsWith( github.ref, 'refs/tags/v' )"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: alice-biometrics/release-creator/@v1.0.5
         with:
           GITHUB_TOKEN: ${{ secrets.PRIVATE_TOKEN }}

--- a/.github/workflows/PullRequest.yml
+++ b/.github/workflows/PullRequest.yml
@@ -11,12 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        node-version: [ 16.x ]
+        node-version: [ 20.x, 21.x ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/Push.yml
+++ b/.github/workflows/Push.yml
@@ -11,13 +11,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        node-version: [ 16.x ]
+        node-version: [ 20.x, 21.x ]
     if: "!startsWith( github.event.head_commit.message, 'version' ) && !startsWith( github.ref, 'refs/tags/v' )"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,6 @@ inputs:
     required: false
     default: false
 runs:
-  using: 'node16'
+  using: node20
   main: 'dist/main.js'
 


### PR DESCRIPTION
Node16 will be deprecated on 09/11/2023 ([link](https://nodejs.org/en/blog/announcements/nodejs16-eol)).